### PR TITLE
Add all gameweek functionality

### DIFF
--- a/app/fpl_api_getters.py
+++ b/app/fpl_api_getters.py
@@ -6,16 +6,17 @@ import asyncio
 import gcsfs
 
 # df = pd.read_csv("players_raw.csv")
-df = pd.read_parquet('gs://fpl_dev_bucket/2022/player_gameweek/player_gameweek_38.parquet')
+df = pd.read_parquet('gs://fpl_dev_bucket/2022/player_gameweek/')
+df.set_index(['gameweek','id'],inplace=True)
 
 
-def manager_gw_picks_api(gw:int, manager_id):
+def manager_gw_picks_api(gw:int , manager_id):
     """Returns a list of dictionaries of all picks a manager made in a gameweek"""
     #Check for valid ID
     if (manager_id is None) or (not manager_id.isdigit()):
         return None
 
-    url = f"https://fantasy.premierleague.com/api/entry/{manager_id}/event/{gw}/picks/"
+    url = f"https://fantasy.premierleague.com/api/entry/{manager_id}/event/{str(gw)}/picks/"
     req = requests.get(url).json()
 
     #Check if ID exists
@@ -25,7 +26,7 @@ def manager_gw_picks_api(gw:int, manager_id):
     squad_list = []
     
     for pick in req["picks"]:
-        player_series =  df.iloc[pick['element']-1]
+        player_series =  df.loc[gw,pick['element']]
         squad_list.append(Player(
             id=pick["element"],
             name = player_series['second_name'],

--- a/app/squad_display.py
+++ b/app/squad_display.py
@@ -114,13 +114,13 @@ def show_squad(complete_div, error_message, manager_id: str, manager_id_2: str,g
     error_message.clear()
 
 
-    squad_1 = manager_gw_picks_api(str(gameweek),manager_id)
+    squad_1 = manager_gw_picks_api(gameweek,manager_id)
     if squad_1 is None:
         with error_message:
             ui.label("Manager ID 1 does not exist or is an invalid ID.")
         return
 
-    squad_2 = manager_gw_picks_api(str(gameweek),manager_id_2)
+    squad_2 = manager_gw_picks_api(gameweek,manager_id_2)
     if squad_2 is None:
         with error_message:
             ui.label("Manager ID 2 does not exist or is an invalid ID.")


### PR DESCRIPTION
Currently, while you can select any gameweek, only player data for gameweek 38 is being used. This PR adds functionality to use all gameweek data by loading in all parquet files stored in specific folder in GCS. Dataframe is indexed on gameweek and player id for quicker search times.