### PR TITLE
Development

### DIFF
--- a/app/generate_squad.py
+++ b/app/generate_squad.py
@@ -82,7 +82,7 @@ async def show_page():
         ##########################################################################
 
         with ui.element("div").classes(
-            "flex flex-row justify-center content-center w-full min-h-screen "
+            "flex flex-row justify-center content-center w-full "
             "bg-white relative bottom-bottom-1 border-sky-400"
         ) as display_div:
             ui.label().classes("w-[calc(50vw_+_40px)] absolute top-0 left-0").style(
@@ -94,9 +94,30 @@ async def show_page():
                 "text-6xl sm:text-7xl text-zinc-900 font-sans font-bold h-auto "
                 "w-full  text-center align-middle mb-6 mt-[60px]"
             )
+            with ui.element("div").classes(
+                "w-full flex flex-row justify-center items-center content-center"
+            ):
+                with ui.element("div").classes(
+                    "max-w-[490px] w-full flex flex-row justify-center content-center"
+                ):
+                    squad_summary_container, squad_summary_display = squad_summary()
 
-            squad_summary_display = squad_summary()
-            squad_display = generate_squad_pitch_layout()
+                    squad_summary_container.classes(
+                        "w-full max-w-[250px] hover:cursor-pointer"
+                    )
+
+                    random_squad_radio = (
+                        ui.radio(
+                            {
+                                True: "Actually Random",
+                                False: "A Real Team Please",
+                            }
+                        )
+                        .props("inline")
+                        .classes("max-w-[350px] w-full")
+                    )
+
+                squad_display = generate_squad_pitch_layout()
 
         display_div.set_visibility(False)
 
@@ -106,8 +127,22 @@ async def show_page():
         ##########################################################################
         ##########################################################################
 
+        random_squad_radio.bind_value(random_squad_toggle, "value")
+
         # Load Display page when Compare button pressed
         generate_button.on(
+            "click",
+            lambda x: generate_squad(
+                landing_div,
+                display_div,
+                squad_display,
+                squad_summary_display,
+                random_squad_toggle.value,
+            ),
+            throttle=1.0,
+        )
+
+        squad_summary_display.on(
             "click",
             lambda x: generate_squad(
                 landing_div,

--- a/app/layout_components/display_page_layout.py
+++ b/app/layout_components/display_page_layout.py
@@ -139,14 +139,13 @@ def transfer_layout():
 def squad_summary():
     with ui.element("div").classes(
         "p-1 rounded-2xl drop-shadow-xl bg-gradient-to-r from-sky-500 via-sky-300 "
-        "to-cyan-400 m-4"
-    ):
+        "to-cyan-400"
+    ) as squad_summary_container:
         squad_summary_display = ui.element("div").classes(
-            " w-[150px] md:w-[250px] flex flex-row justify-centers "
-            "content-start gap-y-0"
+            " flex flex-row justify-centers " "content-start gap-y-0"
         )
 
-    return squad_summary_display
+    return squad_summary_container, squad_summary_display
 
 
 def generate_squad_pitch_layout():

--- a/app/main.py
+++ b/app/main.py
@@ -241,6 +241,11 @@ async def main(client: Client):
     .q-item__section--main~.q-item__section--side {
         padding:0 !important;
     }
+
+
+    .q-gutter-sm, .q-gutter-x-sm {
+        margin-left: 0px;
+    }
     </style>
     """
     )

--- a/app/player.py
+++ b/app/player.py
@@ -124,7 +124,7 @@ class PlayerGameweek(Player):
     def create_player_dialog(
         self,
     ):
-        with ui.dialog() as dialog, ui.card().classes("relative w-72 h-48"):
+        with ui.dialog() as dialog, ui.card().classes("relative w-72 min-h-48"):
             ui.label(f"{self.first_name} {self.second_name}").classes(
                 "w-full h-auto text-center text-lg text-zinc-900 font-medium font-sans "
                 "align-middle"

--- a/app/squad.py
+++ b/app/squad.py
@@ -46,7 +46,7 @@ class Squad:
                     "transparent;border-right: 5px solid transparent; opacity:0.3;"
                 )
 
-            ui.label("FPLCOMPARE").classes(
+            ui.label("Click to Refresh").classes(
                 "text-center w-auto font-medium rounded-full text-stone-100"
             )
 


### PR DESCRIPTION
Add regenerate squad functionality above pitch to prevent having to scroll back up to the main button. Squad summary can be clicked to regenerate the squad.
Also add radio buttons for the two squad types - Value bound to the initial squad type toggle on the landing page.